### PR TITLE
Fixed scope issue when Content-Type not returned

### DIFF
--- a/bolthttp.cfc
+++ b/bolthttp.cfc
@@ -151,7 +151,7 @@ component {
 					result.text = true;
 				}
 			}
-		} else if (ListFindNoCase("png,jpg,jpeg,gif,pdf", ListFirst(ListLast(url, "."), "?"))) {
+		} else if (ListFindNoCase("png,jpg,jpeg,gif,pdf", ListFirst(ListLast(arguments.url, "."), "?"))) {
 			result.text = false;
 		} else {
 			result.text = true;


### PR DESCRIPTION
When a response is missing the `Content-Type` header, it tries to guess if the results should be treated as text based upon the extension in the URL. In Lucee, `listLast(url, ".")` attempts to reference the `URL` scope instead of the argument and generates an exception.